### PR TITLE
Install PortAudio libraries for PyAudio builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update \
         build-essential \
         curl \
         ffmpeg \
+        libportaudio2 \
+        portaudio19-dev \
         nodejs \
         npm \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add libportaudio2 and portaudio19-dev to the Docker build image to satisfy PyAudio's build-time dependencies

## Testing
- pip install --no-cache-dir pyaudio

------
https://chatgpt.com/codex/tasks/task_b_68dbfb2666cc8322b329b87fcdd954c3