### PR TITLE
Streamline Fly deployment dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.swp
+*.swo
+
+# Environment files
+.env
+.env.*
+
+# Node artifacts
+node_modules/
+.npm/
+
+# Byte-compiled / optimized / DLL files
+*.so
+
+# Logs
+*.log
+
+# IDE / editor settings
+.vscode/
+.idea/
+.DS_Store

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -17,6 +17,9 @@ The system consists of:
 #### Prerequisites:
 - Fly.io account
 - Fly CLI installed (`flyctl`)
+- Python dependencies from `requirements.txt`
+  - Only the minimal runtime stack is installed by default.
+  - Optional features that pull in large packages live in `requirements-optional.txt` and should be installed explicitly when you need them.
 
 #### Steps:
 1. Initialize the app:
@@ -36,6 +39,12 @@ The system consists of:
 3. Deploy:
    ```bash
    fly deploy
+   ```
+
+   If you require optional capabilities (e.g. MongoDB persistence or the Hugging Face translation pipeline), pass the build argument `INSTALL_OPTIONAL=true` so the Docker image installs `requirements-optional.txt` as well:
+
+   ```bash
+   fly deploy --build-arg INSTALL_OPTIONAL=true
    ```
 
 ### Option 2: Deploy to Render

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+ARG INSTALL_OPTIONAL=false
+
 # Install system dependencies for Python audio processing and the Node frontend
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -20,8 +22,12 @@ RUN apt-get update \
 
 # Install Python dependencies
 COPY requirements.txt ./requirements.txt
+COPY requirements-optional.txt ./requirements-optional.txt
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
+    && pip install --no-cache-dir -r requirements.txt \
+    && if [ "$INSTALL_OPTIONAL" = "true" ]; then \
+        pip install --no-cache-dir -r requirements-optional.txt; \
+    fi
 
 # Install Node dependencies
 COPY package.json package-lock.json ./

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,15 @@
+# Optional extras that significantly increase image size.
+# Install selectively, e.g. `pip install -r requirements-optional.txt`,
+# when you enable the corresponding features.
+
+# Alternate speech pipeline support via Deepgram
+livekit-plugins-deepgram
+
+# Persistent storage with MongoDB
+motor
+pymongo
+
+# Translation pipeline powered by Hugging Face
+transformers
+# Choose your preferred backend for transformers. PyTorch is the default.
+torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,10 @@
-# Core requirements
+# Core runtime dependencies
 livekit-agents
 livekit-plugins-openai
 livekit-plugins-silero
-livekit-plugins-deepgram
-
-# Database
-pymongo
-motor
-
-# NLP and ML
 openai
-anthropic
-transformers
-torch
-sentence-transformers
-
-# Avatar and UI
-websockets
-requests
-
-# Utilities
 python-dotenv
-pydantic
 
-# Additional requirements for full functionality
-aiohttp
-numpy
-scipy
-sounddevice
-pyaudio
+# Optional components that pull large dependency trees live in
+# requirements-optional.txt. Install them only when you need the
+# corresponding feature set.


### PR DESCRIPTION
## Summary
- trim the default Python requirements to the minimal runtime stack and document optional extras for heavy features
- add a requirements-optional.txt and Docker build argument so optional dependencies can be installed on demand
- ignore local environment and node artifacts to keep the repository clean

## Testing
- pip install -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_b_68dc02e13490832291ec14f19cf7010f