### PR TITLE
Fix config route and avatar loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,8 @@
           downloadAvatarLink.href = '#';
           return;
         }
-        viewer.src = `${url}?pose=idle`;
+        viewer.src = url;
+        viewer.setAttribute('crossorigin', 'anonymous');
         avatarStatus.textContent = `Avatar URL: ${url}`;
         downloadAvatarLink.href = url;
       }

--- a/server.js
+++ b/server.js
@@ -7,6 +7,22 @@ const { AccessToken } = require('livekit-server-sdk');
 const app = express();
 const server = http.createServer(app);
 
+const READY_PLAYER_ME_SUBDOMAIN = process.env.READY_PLAYER_ME_SUBDOMAIN || 'demo';
+const LIVEKIT_URL = process.env.LIVEKIT_URL || 'ws://localhost:7880';
+
+app.use(express.json());
+
+app.get('/config.js', (_req, res) => {
+  res
+    .type('application/javascript')
+    .send(
+      `window.RUNTIME = ${JSON.stringify({
+        READY_PLAYER_ME_SUBDOMAIN,
+        LIVEKIT_URL,
+      })};`
+    );
+});
+
 // Serve static files from the current directory
 app.use(express.static(path.join(__dirname)));
 
@@ -32,7 +48,7 @@ app.get('/token', (req, res) => {
 
     res.json({
       token: at.toJwt(),
-      url: process.env.LIVEKIT_URL || 'ws://localhost:7880',
+      url: LIVEKIT_URL,
       room,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add a /config.js endpoint that exposes Ready Player Me and LiveKit runtime values before static middleware
- default LiveKit URL comes from shared constant used for config and token responses
- remove Ready Player Me pose query string and add crossorigin attribute so avatars can load correctly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dcb197800c8322b48d3c1ce94832c6